### PR TITLE
ADD: Metabase to docker compose

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -28,5 +28,16 @@ services:
     ports:
       - "8000:8000"
 
+  metabase:
+    image: metabase/metabase:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - MB_DB_TYPE=h2
+      - MB_DB_FILE=/metabase-data/metabase.db
+    volumes:
+      - metabase-data:/metabase-data
+
 volumes:
   postgres_data:
+  metabase-data:


### PR DESCRIPTION
Se agrega metabase al docker compose, para visualización y análisis de datos. Se levanta como contenedor independiente.